### PR TITLE
Fixed CloudFlare apex domain redirect and CloudFront routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,18 @@ jobs:
           --tf-var-file="environments/prod.tfvars" 
           terraform-auto-apply
         version: "0.20.8"
+    - name: Invalidate CloudFront cache
+      run: |
+        DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items && contains(Aliases.Items, 'www.defdev.io')].Id | [0]" --output text)
+
+        if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" = "None" ]; then
+          echo "Could not find CloudFront distribution for www.defdev.io"
+          exit 1
+        fi
+
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "/*"
     - name: Always delete credentials file
       if: always()
       run: |

--- a/infra/README.md
+++ b/infra/README.md
@@ -50,10 +50,12 @@ We also build our `CloudFront` distribution which is used to cache the website i
 | [aws_secretsmanager_secret.cloudflare_turnstile_widget](https://registry.terraform.io/providers/hashicorp/aws/5.84.0/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_policy.cloudflare_turnstile_widget](https://registry.terraform.io/providers/hashicorp/aws/5.84.0/docs/resources/secretsmanager_secret_policy) | resource |
 | [aws_secretsmanager_secret_version.cloudflare_turnstile_widget](https://registry.terraform.io/providers/hashicorp/aws/5.84.0/docs/resources/secretsmanager_secret_version) | resource |
+| [cloudflare_dns_record.apex_defdev_io_www_record](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_dns_record.ses_dkim_records](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_dns_record.ses_email_verification](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_dns_record.www_defdev_io_acm_validation](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_dns_record.www_defdev_io_cloudfront_record](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_ruleset.apex_to_www_redirect](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) | resource |
 | [cloudflare_turnstile_widget.this](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/turnstile_widget) | resource |
 | [time_sleep.wait_5_minutes](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/5.84.0/docs/data-sources/caller_identity) | data source |

--- a/infra/cloudflare.tf
+++ b/infra/cloudflare.tf
@@ -19,6 +19,41 @@ resource "cloudflare_dns_record" "www_defdev_io_cloudfront_record" {
   zone_id = "41bd26725ef299b72663216ffa012106"
 }
 
+resource "cloudflare_dns_record" "apex_defdev_io_www_record" {
+  content = "www.defdev.io"
+  name    = "@"
+  proxied = true
+  ttl     = 1
+  type    = "CNAME"
+  zone_id = "41bd26725ef299b72663216ffa012106"
+}
+
+resource "cloudflare_ruleset" "apex_to_www_redirect" {
+  name    = "Apex to WWW Redirect"
+  kind    = "zone"
+  phase   = "http_request_dynamic_redirect"
+  zone_id = "41bd26725ef299b72663216ffa012106"
+
+  rules = [
+    {
+      action      = "redirect"
+      description = "Redirect defdev.io to www.defdev.io"
+      enabled     = true
+      expression  = "http.host eq \"defdev.io\""
+
+      action_parameters = {
+        from_value = {
+          status_code = 301
+          target_url = {
+            expression = "concat(\"https://www.defdev.io\", http.request.uri.path)"
+          }
+          preserve_query_string = true
+        }
+      }
+    }
+  ]
+}
+
 resource "cloudflare_dns_record" "ses_email_verification" {
   content = module.ses.domain_verification_token
   name    = "_amazonses.defdev.io"
@@ -52,6 +87,11 @@ moved {
 moved {
   from = cloudflare_record.www_defdev_io_cloudfront_record
   to   = cloudflare_dns_record.www_defdev_io_cloudfront_record
+}
+
+moved {
+  from = cloudflare_record.apex_defdev_io_www_record
+  to   = cloudflare_dns_record.apex_defdev_io_www_record
 }
 
 moved {

--- a/infra/modules/terraform-aws-cloudfront/README.md
+++ b/infra/modules/terraform-aws-cloudfront/README.md
@@ -5,6 +5,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.84 |
 
 ## Providers
@@ -22,6 +23,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_function.url_rewrite](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 
 ## Inputs

--- a/infra/modules/terraform-aws-cloudfront/main.tf
+++ b/infra/modules/terraform-aws-cloudfront/main.tf
@@ -28,6 +28,11 @@ resource "aws_cloudfront_distribution" "this" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.url_rewrite.arn
+    }
   }
 
   restrictions {
@@ -42,4 +47,31 @@ resource "aws_cloudfront_distribution" "this" {
     minimum_protocol_version = "TLSv1.1_2016"
     ssl_support_method       = "sni-only"
   }
+}
+
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "${replace(var.origin_id, ".", "-")}-url-rewrite"
+  runtime = "cloudfront-js-1.0"
+  publish = true
+  comment = "Rewrite static routes to index.html for S3 origin"
+  code    = <<-EOT
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  // Keep direct file requests unchanged (assets, images, etc.)
+  if (uri.includes('.')) {
+    return request;
+  }
+
+  // Map clean URLs to static index files.
+  if (uri.endsWith('/')) {
+    request.uri = uri + 'index.html';
+  } else {
+    request.uri = uri + '/index.html';
+  }
+
+  return request;
+}
+EOT
 }

--- a/infra/modules/terraform-aws-cloudfront/versions.tf
+++ b/infra/modules/terraform-aws-cloudfront/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = "~> 1.10"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This pull request introduces several infrastructure improvements for the deployment and routing of the `defdev.io` site. The main changes include adding a CloudFront function to rewrite URLs for static site hosting, configuring Cloudflare for apex-to-www redirection, and ensuring cache invalidation after deployment. These updates improve user experience, SEO, and deployment reliability.

**CloudFront Static Site Improvements:**

* Added an `aws_cloudfront_function` (`url_rewrite`) that rewrites incoming requests to serve `index.html` for clean URLs, ensuring proper routing for static sites hosted on S3. This function is now associated with the CloudFront distribution for viewer requests. [[1]](diffhunk://#diff-dfd591e5f98a2115dae13b50c7a49aa843ae6afcb14f965401a69756bd3f8ac0R31-R35) [[2]](diffhunk://#diff-dfd591e5f98a2115dae13b50c7a49aa843ae6afcb14f965401a69756bd3f8ac0R51-R77) [[3]](diffhunk://#diff-737bb5f00b602e96bcce101f31a2a7e1094a039abd7344a1e85857574d6e96d5R26)
* Updated Terraform module requirements to specify Terraform version `~> 1.10` for compatibility. [[1]](diffhunk://#diff-737bb5f00b602e96bcce101f31a2a7e1094a039abd7344a1e85857574d6e96d5R8) [[2]](diffhunk://#diff-24bf0f2b5fb32f3131ef8d5acc319aea8ec0714232fd7a4f80ec37d64a4f648aR2-R3)

**Cloudflare DNS and Redirect Enhancements:**

* Added a new DNS record (`apex_defdev_io_www_record`) to point the apex domain (`defdev.io`) to `www.defdev.io` via a proxied CNAME, and migrated the resource in Terraform state. [[1]](diffhunk://#diff-68305ed09b602d1d87bd153ddd2f125d035831de05e5c2cf3e6b19c4db784b72R22-R56) [[2]](diffhunk://#diff-68305ed09b602d1d87bd153ddd2f125d035831de05e5c2cf3e6b19c4db784b72R92-R96) [[3]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4R53-R58)
* Introduced a Cloudflare ruleset (`apex_to_www_redirect`) to perform a 301 redirect from `defdev.io` to `www.defdev.io`, preserving paths and query strings for SEO and usability. [[1]](diffhunk://#diff-68305ed09b602d1d87bd153ddd2f125d035831de05e5c2cf3e6b19c4db784b72R22-R56) [[2]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4R53-R58)

**Deployment Process Improvements:**

* Added a deployment step to invalidate the CloudFront cache after each deploy, ensuring users receive the latest content immediately.

These changes collectively enhance routing, ensure fresh content delivery, and improve the static site's behavior for both users and search engines.