### PR TITLE
fix(infra): add CORS headers for giscus-theme.css so giscus.app can load it

### DIFF
--- a/infra/modules/terraform-aws-cloudfront/README.md
+++ b/infra/modules/terraform-aws-cloudfront/README.md
@@ -25,6 +25,7 @@ No modules.
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_function.url_rewrite](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_cloudfront_response_headers_policy.giscus_theme_cors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 
 ## Inputs
 

--- a/infra/modules/terraform-aws-cloudfront/main.tf
+++ b/infra/modules/terraform-aws-cloudfront/main.tf
@@ -35,6 +35,27 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "/giscus-theme.css"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = var.origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy     = "https-only"
+    min_ttl                    = 0
+    default_ttl                = 3600
+    max_ttl                    = 86400
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.giscus_theme_cors.id
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "whitelist"

--- a/infra/modules/terraform-aws-cloudfront/response_headers.tf
+++ b/infra/modules/terraform-aws-cloudfront/response_headers.tf
@@ -1,0 +1,22 @@
+resource "aws_cloudfront_response_headers_policy" "giscus_theme_cors" {
+  name    = "${replace(var.origin_id, ".", "-")}-giscus-theme-cors"
+  comment = "Allow giscus.app to fetch the custom theme stylesheet cross-origin"
+
+  cors_config {
+    access_control_allow_credentials = false
+
+    access_control_allow_headers {
+      items = ["*"]
+    }
+
+    access_control_allow_methods {
+      items = ["GET", "HEAD"]
+    }
+
+    access_control_allow_origins {
+      items = ["https://giscus.app"]
+    }
+
+    origin_override = true
+  }
+}


### PR DESCRIPTION
This pull request adds support for serving the `/giscus-theme.css` file via CloudFront with a custom CORS (Cross-Origin Resource Sharing) policy, specifically allowing requests from `https://giscus.app`. The changes ensure that the stylesheet can be fetched cross-origin in a secure and controlled manner.

**CloudFront Distribution Enhancements:**

* Added an `ordered_cache_behavior` for the `/giscus-theme.css` path in `aws_cloudfront_distribution.this`, specifying allowed methods, cache settings, and associating a custom response headers policy for CORS.

**CORS Policy Implementation:**

* Introduced a new `aws_cloudfront_response_headers_policy.giscus_theme_cors` resource that defines CORS headers to allow `GET` and `HEAD` requests from `https://giscus.app`, with permissive headers and no credentials.
* Updated the documentation in `README.md` to reference the new `aws_cloudfront_response_headers_policy.giscus_theme_cors` resource.